### PR TITLE
Auto choose between $w or $h when a fixed image ratio is given for container with variable ratio.

### DIFF
--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -245,7 +245,9 @@
 					var pattern = o[value + 'Pattern'];
 					
 					if (urlFormat[value] && size[value] !== undefined) {
-						if (fixRatioInfo.isEnabled && fixRatioState.isValid && fixRatioState[value]) {
+						if (fixRatioInfo.isEnabled &&
+							fixRatioState.isValid &&
+							fixRatioState[value]) {
 							format = format.replace(pattern, '0');
 						} else {
 							format = format.replace(pattern, ~~(size[value] * o.devicePixelRatio));

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -201,7 +201,7 @@
 		return {
 			isEnabled: isFixRatio,
 			imageRatio: imageRatio
-		}
+		};
 	}
 
 	var _getUrlFromFormat = function (t, o, size) {
@@ -220,7 +220,7 @@
 		};
 		if (!!format) {
 			if (!o.bypassDefaultFormat) {
-				//Compute format template exist
+				// Compute format template exist
 				$.each(['width', 'height'], function (i, value) {
 					var pattern = o[value + 'Pattern'];
 					urlFormat[value] = pattern.test(format);

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -234,18 +234,8 @@
 					//Compute good size keeping ratio and covering all the size;
 					if (size.width > 0 && size.height > 0) {
 						var sizeRatio = size.width / size.height;
-						var isWidth = true;
-						
-						if (sizeRatio <= 1) {
-							//Landscape or square container
-							isWidth = fixRatioInfo.imageRatio < sizeRatio ? false : true;
-						} else {
-							//Portrait or else.
-							isWidth = fixRatioInfo.imageRatio > sizeRatio ? true : false;
-						}
-
-						fixRatioState.width = isWidth;
-						fixRatioState.height = !isWidth;
+						fixRatioState.width = fixRatioInfo.imageRatio >= sizeRatio;
+						fixRatioState.height = !fixRatioState.width;
 						fixRatioState.isValid = true;
 					}
 				}

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -265,7 +265,9 @@
 	};
 
 	var _hasRatioChanged = function (size, compareTo) {
-		return Math.ceil((size.width / size.height) * 100) !== Math.ceil((compareTo.width / compareTo.height) * 100);
+		var sizeRatio = Math.ceil((size.width / size.height) * 100);
+		var compareRatio = Math.ceil((compareTo.width / compareTo.height) * 100);
+		return sizeRatio !== compareRatio;
 	};
 	
 	var _update = function (t, o) {

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -240,7 +240,7 @@
 					}
 				}
 
-				//Compute final format url
+				// Compute final format url
 				$.each(['width', 'height'], function (i, value) {
 					var pattern = o[value + 'Pattern'];
 					

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -202,7 +202,7 @@
 			isEnabled: isFixRatio,
 			imageRatio: imageRatio
 		};
-	}
+	};
 
 	var _getUrlFromFormat = function (t, o, size) {
 		var format = t.attr(getValue(o.dataAttribute));

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -284,7 +284,7 @@
 				if (!o.fetchSmallerImages) {
 					var fixRatioInfo = _getFixRatioInfo(t, o);
 					var ratioChanged = _hasRatioChanged(size, previousSize);
-					var isSmaller = _isSizeSmallerThen(size, previousSize)
+					var isSmaller = _isSizeSmallerThen(size, previousSize);
 					if (isSmaller && !ratioChanged) {
 						// abort
 						abort = true;

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -193,7 +193,7 @@
 		return false;
 	};
 	
-	var _getFixRatioInfo = function (t) {
+	var _getFixRatioInfo = function (t, o) {
 		var attrImageRatioValue = t.attr(getValue(o.dataAttributeRatio));
 		var imageRatio = parseFloat(attrImageRatioValue);
 		var isFixRatio = !!attrImageRatioValue && imageRatio > 0;
@@ -206,7 +206,7 @@
 
 	var _getUrlFromFormat = function (t, o, size) {
 		var format = t.attr(getValue(o.dataAttribute));
-		var fixRatioInfo = _getFixRatioInfo(t);
+		var fixRatioInfo = _getFixRatioInfo(t, o);
 		var fixRatioState = {
 			isValid: false,
 			width: false,
@@ -292,7 +292,7 @@
 
 			if (urlFormatSuccess && sizeSucces) {
 				if (!o.fetchSmallerImages) {
-					var fixRatioInfo = _getFixRatioInfo(t);
+					var fixRatioInfo = _getFixRatioInfo(t, o);
 					var ratioChanged = _hasRatioChanged(size, previousSize);
 					var isSmaller = _isSizeSmallerThen(size, previousSize)
 					if (isSmaller && !ratioChanged) {

--- a/src/jquery.jit-image.js
+++ b/src/jquery.jit-image.js
@@ -194,7 +194,7 @@
 	};
 	
 	var _getFixRatioInfo = function (t) {
-		var attrImageRatioValue = t.attr('data-jit-image-ratio');
+		var attrImageRatioValue = t.attr(getValue(o.dataAttributeRatio));
 		var imageRatio = parseFloat(attrImageRatioValue);
 		var isFixRatio = !!attrImageRatioValue && imageRatio > 0;
 
@@ -386,6 +386,7 @@
 	var _defaults = {
 		container: null,
 		dataAttribute: dataAttribute, // can also be function
+		dataAttributeRatio: 'data-jit-image-ratio',
 		defaultSelector: defaultSelector,
 		containerDataAttribute: 'data-container', // can also be function
 		size: _getSize,


### PR DESCRIPTION
Add the new feature for auto detecting the best direction to maintain the original aspect ratio of the image to fillup the container hole with a detection of changed aspect ratio of the container to still keep the best resize available cross platform.